### PR TITLE
highest_supp_cmake_cxx_standard.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 
 option(SSVU "Include ssvu::FastFunc" OFF)
 if (SSVU)
+  include_directories(SYSTEM clugston_styled)
   add_definitions(-DADD_SSVU)
 endif()
 

--- a/folly/CPortability.h
+++ b/folly/CPortability.h
@@ -25,26 +25,26 @@
  * Portable version check.
  */
 #ifndef __GNUC_PREREQ
-# if defined __GNUC__ && defined __GNUC_MINOR__
+#if defined __GNUC__ && defined __GNUC_MINOR__
 /* nolint */
-#  define __GNUC_PREREQ(maj, min) ((__GNUC__ << 16) + __GNUC_MINOR__ >= \
-                                   ((maj) << 16) + (min))
-# else
+#define __GNUC_PREREQ(maj, min) \
+  ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+#else
 /* nolint */
-#  define __GNUC_PREREQ(maj, min) 0
-# endif
+#define __GNUC_PREREQ(maj, min) 0
+#endif
 #endif
 
 // portable version check for clang
 #ifndef __CLANG_PREREQ
-# if defined __clang__ && defined __clang_major__ && defined __clang_minor__
+#if defined __clang__ && defined __clang_major__ && defined __clang_minor__
 /* nolint */
-#  define __CLANG_PREREQ(maj, min) \
-    ((__clang_major__ << 16) + __clang_minor__ >= ((maj) << 16) + (min))
-# else
+#define __CLANG_PREREQ(maj, min) \
+  ((__clang_major__ << 16) + __clang_minor__ >= ((maj) << 16) + (min))
+#else
 /* nolint */
-#  define __CLANG_PREREQ(maj, min) 0
-# endif
+#define __CLANG_PREREQ(maj, min) 0
+#endif
 #endif
 
 #if defined(__has_builtin)
@@ -59,46 +59,50 @@
 #define FOLLY_HAS_FEATURE(...) 0
 #endif
 
-#if defined(__has_include)
-#define FOLLY_HAS_INCLUDE(...) __has_include(__VA_ARGS__)
-#else
-#define FOLLY_HAS_INCLUDE(...) 0
-#endif
-
-/* Define a convenience macro to test when address sanitizer is being used
- * across the different compilers (e.g. clang, gcc) */
+/* FOLLY_SANITIZE_ADDRESS is defined to 1 if the current compilation unit
+ * is being compiled with ASAN enabled.
+ *
+ * Beware when using this macro in a header file: this macro may change values
+ * across compilation units if some libraries are built with ASAN enabled
+ * and some built with ASAN disabled.  For instance, this may occur, if folly
+ * itself was compiled without ASAN but a downstream project that uses folly is
+ * compiling with ASAN enabled.
+ *
+ * Use FOLLY_ASAN_ENABLED (defined in folly-config.h) to check if folly itself
+ * was compiled with ASAN enabled.
+ */
 #if FOLLY_HAS_FEATURE(address_sanitizer) || __SANITIZE_ADDRESS__
-# define FOLLY_SANITIZE_ADDRESS 1
+#define FOLLY_SANITIZE_ADDRESS 1
 #endif
 
 /* Define attribute wrapper for function attribute used to disable
  * address sanitizer instrumentation. Unfortunately, this attribute
  * has issues when inlining is used, so disable that as well. */
 #ifdef FOLLY_SANITIZE_ADDRESS
-# if defined(__clang__)
-#  if __has_attribute(__no_sanitize__)
-#   define FOLLY_DISABLE_ADDRESS_SANITIZER \
-      __attribute__((__no_sanitize__("address"), __noinline__))
-#  elif __has_attribute(__no_address_safety_analysis__)
-#   define FOLLY_DISABLE_ADDRESS_SANITIZER \
-      __attribute__((__no_address_safety_analysis__, __noinline__))
-#  elif __has_attribute(__no_sanitize_address__)
-#   define FOLLY_DISABLE_ADDRESS_SANITIZER \
-      __attribute__((__no_sanitize_address__, __noinline__))
-#  endif
-# elif defined(__GNUC__)
-#  define FOLLY_DISABLE_ADDRESS_SANITIZER \
-     __attribute__((__no_address_safety_analysis__, __noinline__))
-# endif
+#if defined(__clang__)
+#if __has_attribute(__no_sanitize__)
+#define FOLLY_DISABLE_ADDRESS_SANITIZER \
+  __attribute__((__no_sanitize__("address"), __noinline__))
+#elif __has_attribute(__no_address_safety_analysis__)
+#define FOLLY_DISABLE_ADDRESS_SANITIZER \
+  __attribute__((__no_address_safety_analysis__, __noinline__))
+#elif __has_attribute(__no_sanitize_address__)
+#define FOLLY_DISABLE_ADDRESS_SANITIZER \
+  __attribute__((__no_sanitize_address__, __noinline__))
+#endif
+#elif defined(__GNUC__)
+#define FOLLY_DISABLE_ADDRESS_SANITIZER \
+  __attribute__((__no_address_safety_analysis__, __noinline__))
+#endif
 #endif
 #ifndef FOLLY_DISABLE_ADDRESS_SANITIZER
-# define FOLLY_DISABLE_ADDRESS_SANITIZER
+#define FOLLY_DISABLE_ADDRESS_SANITIZER
 #endif
 
 /* Define a convenience macro to test when thread sanitizer is being used
  * across the different compilers (e.g. clang, gcc) */
 #if FOLLY_HAS_FEATURE(thread_sanitizer) || __SANITIZE_THREAD__
-# define FOLLY_SANITIZE_THREAD 1
+#define FOLLY_SANITIZE_THREAD 1
 #endif
 
 /**
@@ -120,31 +124,31 @@
  * Macro for marking functions as having public visibility.
  */
 #if defined(__GNUC__)
-# if __GNUC_PREREQ(4, 9)
-#  define FOLLY_EXPORT [[gnu::visibility("default")]]
-# else
-#  define FOLLY_EXPORT __attribute__((__visibility__("default")))
-# endif
+#if __GNUC_PREREQ(4, 9)
+#define FOLLY_EXPORT [[gnu::visibility("default")]]
 #else
-# define FOLLY_EXPORT
+#define FOLLY_EXPORT __attribute__((__visibility__("default")))
+#endif
+#else
+#define FOLLY_EXPORT
 #endif
 
 // noinline
 #ifdef _MSC_VER
-# define FOLLY_NOINLINE __declspec(noinline)
+#define FOLLY_NOINLINE __declspec(noinline)
 #elif defined(__clang__) || defined(__GNUC__)
-# define FOLLY_NOINLINE __attribute__((__noinline__))
+#define FOLLY_NOINLINE __attribute__((__noinline__))
 #else
-# define FOLLY_NOINLINE
+#define FOLLY_NOINLINE
 #endif
 
 // always inline
 #ifdef _MSC_VER
-# define FOLLY_ALWAYS_INLINE __forceinline
+#define FOLLY_ALWAYS_INLINE __forceinline
 #elif defined(__clang__) || defined(__GNUC__)
-# define FOLLY_ALWAYS_INLINE inline __attribute__((__always_inline__))
+#define FOLLY_ALWAYS_INLINE inline __attribute__((__always_inline__))
 #else
-# define FOLLY_ALWAYS_INLINE inline
+#define FOLLY_ALWAYS_INLINE inline
 #endif
 
 // attribute hidden

--- a/folly/Portability.h
+++ b/folly/Portability.h
@@ -18,9 +18,8 @@
 
 #include <cstddef>
 
-#include <folly/portability/Config.h>
-
 #include <folly/CPortability.h>
+#include <folly/portability/Config.h>
 
 // Unaligned loads and stores
 namespace folly {
@@ -36,17 +35,17 @@ constexpr bool kHasUnalignedAccess = false;
 
 // NOTE: this will only do checking in msvc with versions that support /analyze
 #if _MSC_VER
-# ifdef _USE_ATTRIBUTES_FOR_SAL
-#    undef _USE_ATTRIBUTES_FOR_SAL
-# endif
+#ifdef _USE_ATTRIBUTES_FOR_SAL
+#undef _USE_ATTRIBUTES_FOR_SAL
+#endif
 /* nolint */
-# define _USE_ATTRIBUTES_FOR_SAL 1
-# include <sal.h> // @manual
-# define FOLLY_PRINTF_FORMAT _Printf_format_string_
-# define FOLLY_PRINTF_FORMAT_ATTR(format_param, dots_param) /**/
+#define _USE_ATTRIBUTES_FOR_SAL 1
+#include <sal.h> // @manual
+#define FOLLY_PRINTF_FORMAT _Printf_format_string_
+#define FOLLY_PRINTF_FORMAT_ATTR(format_param, dots_param) /**/
 #else
-# define FOLLY_PRINTF_FORMAT /**/
-# define FOLLY_PRINTF_FORMAT_ATTR(format_param, dots_param) \
+#define FOLLY_PRINTF_FORMAT /**/
+#define FOLLY_PRINTF_FORMAT_ATTR(format_param, dots_param) \
   __attribute__((__format__(__printf__, format_param, dots_param)))
 #endif
 
@@ -68,16 +67,16 @@ constexpr bool kHasUnalignedAccess = false;
 
 // target
 #ifdef _MSC_VER
-# define FOLLY_TARGET_ATTRIBUTE(target)
+#define FOLLY_TARGET_ATTRIBUTE(target)
 #else
-# define FOLLY_TARGET_ATTRIBUTE(target) __attribute__((__target__(target)))
+#define FOLLY_TARGET_ATTRIBUTE(target) __attribute__((__target__(target)))
 #endif
 
 // detection for 64 bit
 #if defined(__x86_64__) || defined(_M_X64)
-# define FOLLY_X64 1
+#define FOLLY_X64 1
 #else
-# define FOLLY_X64 0
+#define FOLLY_X64 0
 #endif
 
 #if defined(__arm__)
@@ -87,15 +86,15 @@ constexpr bool kHasUnalignedAccess = false;
 #endif
 
 #if defined(__aarch64__)
-# define FOLLY_AARCH64 1
+#define FOLLY_AARCH64 1
 #else
-# define FOLLY_AARCH64 0
+#define FOLLY_AARCH64 0
 #endif
 
-#if defined (__powerpc64__)
-# define FOLLY_PPC64 1
+#if defined(__powerpc64__)
+#define FOLLY_PPC64 1
 #else
-# define FOLLY_PPC64 0
+#define FOLLY_PPC64 0
 #endif
 
 namespace folly {
@@ -107,7 +106,13 @@ constexpr bool kIsArchPPC64 = FOLLY_PPC64 == 1;
 
 namespace folly {
 
-#if FOLLY_SANITIZE_ADDRESS
+/**
+ * folly::kIsSanitizeAddress reports if folly was compiled with ASAN
+ * enabled.  Note that for compilation units outside of folly that include
+ * folly/Portability.h, the value of kIsSanitizeAddress may be different
+ * from whether or not the current compilation unit is being compiled with ASAN.
+ */
+#if FOLLY_ASAN_ENABLED
 constexpr bool kIsSanitizeAddress = true;
 #else
 constexpr bool kIsSanitizeAddress = false;
@@ -128,53 +133,55 @@ constexpr bool kIsSanitize = false;
 
 // packing is very ugly in msvc
 #ifdef _MSC_VER
-# define FOLLY_PACK_ATTR /**/
-# define FOLLY_PACK_PUSH __pragma(pack(push, 1))
-# define FOLLY_PACK_POP __pragma(pack(pop))
+#define FOLLY_PACK_ATTR /**/
+#define FOLLY_PACK_PUSH __pragma(pack(push, 1))
+#define FOLLY_PACK_POP __pragma(pack(pop))
 #elif defined(__clang__) || defined(__GNUC__)
-# define FOLLY_PACK_ATTR __attribute__((__packed__))
-# define FOLLY_PACK_PUSH /**/
-# define FOLLY_PACK_POP /**/
+#define FOLLY_PACK_ATTR __attribute__((__packed__))
+#define FOLLY_PACK_PUSH /**/
+#define FOLLY_PACK_POP /**/
 #else
-# define FOLLY_PACK_ATTR /**/
-# define FOLLY_PACK_PUSH /**/
-# define FOLLY_PACK_POP /**/
+#define FOLLY_PACK_ATTR /**/
+#define FOLLY_PACK_PUSH /**/
+#define FOLLY_PACK_POP /**/
 #endif
 
 // Generalize warning push/pop.
 #if defined(_MSC_VER)
-# define FOLLY_PUSH_WARNING __pragma(warning(push))
-# define FOLLY_POP_WARNING __pragma(warning(pop))
+#define FOLLY_PUSH_WARNING __pragma(warning(push))
+#define FOLLY_POP_WARNING __pragma(warning(pop))
 // Disable the GCC warnings.
-# define FOLLY_GNU_DISABLE_WARNING(warningName)
-# define FOLLY_GCC_DISABLE_WARNING(warningName)
-# define FOLLY_CLANG_DISABLE_WARNING(warningName)
-# define FOLLY_MSVC_DISABLE_WARNING(warningNumber) __pragma(warning(disable: warningNumber))
+#define FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName)
+#define FOLLY_CLANG_DISABLE_WARNING(warningName)
+#define FOLLY_MSVC_DISABLE_WARNING(warningNumber) \
+  __pragma(warning(disable : warningNumber))
 #elif defined(__GNUC__)
 // Clang & GCC
-# define FOLLY_PUSH_WARNING _Pragma("GCC diagnostic push")
-# define FOLLY_POP_WARNING _Pragma("GCC diagnostic pop")
-# define FOLLY_GNU_DISABLE_WARNING_INTERNAL2(warningName) #warningName
-# define FOLLY_GNU_DISABLE_WARNING(warningName) \
-  _Pragma(                                      \
-  FOLLY_GNU_DISABLE_WARNING_INTERNAL2(GCC diagnostic ignored warningName))
-# ifdef __clang__
-#  define FOLLY_CLANG_DISABLE_WARNING(warningName) FOLLY_GNU_DISABLE_WARNING(warningName)
-#  define FOLLY_GCC_DISABLE_WARNING(warningName)
-# else
-#  define FOLLY_CLANG_DISABLE_WARNING(warningName)
-#  define FOLLY_GCC_DISABLE_WARNING(warningName) FOLLY_GNU_DISABLE_WARNING(warningName)
-# endif
-# define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#define FOLLY_PUSH_WARNING _Pragma("GCC diagnostic push")
+#define FOLLY_POP_WARNING _Pragma("GCC diagnostic pop")
+#define FOLLY_GNU_DISABLE_WARNING_INTERNAL2(warningName) #warningName
+#define FOLLY_GNU_DISABLE_WARNING(warningName) \
+  _Pragma(                                     \
+      FOLLY_GNU_DISABLE_WARNING_INTERNAL2(GCC diagnostic ignored warningName))
+#ifdef __clang__
+#define FOLLY_CLANG_DISABLE_WARNING(warningName) \
+  FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName)
 #else
-# define FOLLY_PUSH_WARNING
-# define FOLLY_POP_WARNING
-# define FOLLY_GNU_DISABLE_WARNING(warningName)
-# define FOLLY_GCC_DISABLE_WARNING(warningName)
-# define FOLLY_CLANG_DISABLE_WARNING(warningName)
-# define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#define FOLLY_CLANG_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName) \
+  FOLLY_GNU_DISABLE_WARNING(warningName)
 #endif
-
+#define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#else
+#define FOLLY_PUSH_WARNING
+#define FOLLY_POP_WARNING
+#define FOLLY_GNU_DISABLE_WARNING(warningName)
+#define FOLLY_GCC_DISABLE_WARNING(warningName)
+#define FOLLY_CLANG_DISABLE_WARNING(warningName)
+#define FOLLY_MSVC_DISABLE_WARNING(warningNumber)
+#endif
 
 #ifdef FOLLY_HAVE_SHADOW_LOCAL_WARNINGS
 #define FOLLY_GCC_DISABLE_NEW_SHADOW_WARNINGS            \
@@ -197,11 +204,11 @@ FOLLY_GCC_DISABLE_NEW_SHADOW_WARNINGS
  * (but remember __thread has different semantics when using emutls (ex. apple))
  */
 #if defined(_MSC_VER)
-# define FOLLY_TLS __declspec(thread)
+#define FOLLY_TLS __declspec(thread)
 #elif defined(__GNUC__) || defined(__clang__)
-# define FOLLY_TLS __thread
+#define FOLLY_TLS __thread
 #else
-# error cannot define platform specific thread local storage
+#error cannot define platform specific thread local storage
 #endif
 
 #if FOLLY_MOBILE
@@ -213,11 +220,11 @@ FOLLY_GCC_DISABLE_NEW_SHADOW_WARNINGS
 // up in a macro to make forward-declarations easier.
 #if FOLLY_USE_LIBCPP
 #include <__config> // @manual
-#define FOLLY_NAMESPACE_STD_BEGIN     _LIBCPP_BEGIN_NAMESPACE_STD
-#define FOLLY_NAMESPACE_STD_END       _LIBCPP_END_NAMESPACE_STD
+#define FOLLY_NAMESPACE_STD_BEGIN _LIBCPP_BEGIN_NAMESPACE_STD
+#define FOLLY_NAMESPACE_STD_END _LIBCPP_END_NAMESPACE_STD
 #else
-#define FOLLY_NAMESPACE_STD_BEGIN     namespace std {
-#define FOLLY_NAMESPACE_STD_END       }
+#define FOLLY_NAMESPACE_STD_BEGIN namespace std {
+#define FOLLY_NAMESPACE_STD_END }
 #endif
 
 // If the new c++ ABI is used, __cxx11 inline namespace needs to be added to
@@ -225,10 +232,10 @@ FOLLY_GCC_DISABLE_NEW_SHADOW_WARNINGS
 #if _GLIBCXX_USE_CXX11_ABI
 #define FOLLY_GLIBCXX_NAMESPACE_CXX11_BEGIN \
   inline _GLIBCXX_BEGIN_NAMESPACE_CXX11
-# define FOLLY_GLIBCXX_NAMESPACE_CXX11_END   _GLIBCXX_END_NAMESPACE_CXX11
+#define FOLLY_GLIBCXX_NAMESPACE_CXX11_END _GLIBCXX_END_NAMESPACE_CXX11
 #else
-# define FOLLY_GLIBCXX_NAMESPACE_CXX11_BEGIN
-# define FOLLY_GLIBCXX_NAMESPACE_CXX11_END
+#define FOLLY_GLIBCXX_NAMESPACE_CXX11_BEGIN
+#define FOLLY_GLIBCXX_NAMESPACE_CXX11_END
 #endif
 
 // MSVC specific defines
@@ -238,10 +245,10 @@ FOLLY_GCC_DISABLE_NEW_SHADOW_WARNINGS
 
 // compiler specific to compiler specific
 // nolint
-# define __PRETTY_FUNCTION__ __FUNCSIG__
+#define __PRETTY_FUNCTION__ __FUNCSIG__
 
 // Hide a GCC specific thing that breaks MSVC if left alone.
-# define __extension__
+#define __extension__
 
 // We have compiler support for the newest of the new, but
 // MSVC doesn't tell us that.
@@ -274,41 +281,41 @@ constexpr auto kIsBigEndian = !kIsLittleEndian;
 } // namespace folly
 
 #ifndef FOLLY_SSE
-# if defined(__SSE4_2__)
-#  define FOLLY_SSE 4
-#  define FOLLY_SSE_MINOR 2
-# elif defined(__SSE4_1__)
-#  define FOLLY_SSE 4
-#  define FOLLY_SSE_MINOR 1
-# elif defined(__SSE4__)
-#  define FOLLY_SSE 4
-#  define FOLLY_SSE_MINOR 0
-# elif defined(__SSE3__)
-#  define FOLLY_SSE 3
-#  define FOLLY_SSE_MINOR 0
-# elif defined(__SSE2__)
-#  define FOLLY_SSE 2
-#  define FOLLY_SSE_MINOR 0
-# elif defined(__SSE__)
-#  define FOLLY_SSE 1
-#  define FOLLY_SSE_MINOR 0
-# else
-#  define FOLLY_SSE 0
-#  define FOLLY_SSE_MINOR 0
-# endif
+#if defined(__SSE4_2__)
+#define FOLLY_SSE 4
+#define FOLLY_SSE_MINOR 2
+#elif defined(__SSE4_1__)
+#define FOLLY_SSE 4
+#define FOLLY_SSE_MINOR 1
+#elif defined(__SSE4__)
+#define FOLLY_SSE 4
+#define FOLLY_SSE_MINOR 0
+#elif defined(__SSE3__)
+#define FOLLY_SSE 3
+#define FOLLY_SSE_MINOR 0
+#elif defined(__SSE2__)
+#define FOLLY_SSE 2
+#define FOLLY_SSE_MINOR 0
+#elif defined(__SSE__)
+#define FOLLY_SSE 1
+#define FOLLY_SSE_MINOR 0
+#else
+#define FOLLY_SSE 0
+#define FOLLY_SSE_MINOR 0
+#endif
 #endif
 
 #define FOLLY_SSE_PREREQ(major, minor) \
   (FOLLY_SSE > major || FOLLY_SSE == major && FOLLY_SSE_MINOR >= minor)
 
 #ifndef FOLLY_NEON
-# if defined(__ARM_NEON)
-#  define FOLLY_NEON 1
-# endif
+#if defined(__ARM_NEON) || defined(__ARM_NEON__)
+#define FOLLY_NEON 1
+#endif
 #endif
 
 #if FOLLY_UNUSUAL_GFLAGS_NAMESPACE
-namespace FOLLY_GFLAGS_NAMESPACE { }
+namespace FOLLY_GFLAGS_NAMESPACE {}
 namespace gflags {
 using namespace FOLLY_GFLAGS_NAMESPACE;
 } // namespace gflags
@@ -322,7 +329,7 @@ using namespace FOLLY_GFLAGS_NAMESPACE;
 // RTTI may not be enabled for this compilation unit.
 #if defined(__GXX_RTTI) || defined(__cpp_rtti) || \
     (defined(_MSC_VER) && defined(_CPPRTTI))
-# define FOLLY_HAS_RTTI 1
+#define FOLLY_HAS_RTTI 1
 #endif
 
 #if defined(__APPLE__) || defined(_MSC_VER)
@@ -370,6 +377,12 @@ constexpr auto kIsGlibcxx = false;
 constexpr auto kIsLibcpp = true;
 #else
 constexpr auto kIsLibcpp = false;
+#endif
+
+#if FOLLY_USE_LIBSTDCPP
+constexpr auto kIsLibstdcpp = true;
+#else
+constexpr auto kIsLibstdcpp = false;
 #endif
 
 #if _MSC_VER
@@ -426,7 +439,11 @@ constexpr auto kCpplibVer = 0;
 #define FOLLY_STORAGE_CONSTEXPR
 #define FOLLY_STORAGE_CPP14_CONSTEXPR
 #else
+#if __ICC
+#define FOLLY_STORAGE_CONSTEXPR
+#else
 #define FOLLY_STORAGE_CONSTEXPR constexpr
+#endif
 #if FOLLY_USE_CPP14_CONSTEXPR
 #define FOLLY_STORAGE_CPP14_CONSTEXPR constexpr
 #else
@@ -434,7 +451,7 @@ constexpr auto kCpplibVer = 0;
 #endif
 #endif
 
-#if __cpp_coroutines >= 201703L && FOLLY_HAS_INCLUDE(<experimental/coroutine>)
+#if __cpp_coroutines >= 201703L && __has_include(<experimental/coroutine>)
 #define FOLLY_HAS_COROUTINES 1
 #elif _MSC_VER && _RESUMABLE_FUNCTIONS_SUPPORTED
 #define FOLLY_HAS_COROUTINES 1
@@ -445,3 +462,39 @@ constexpr auto kCpplibVer = 0;
     (_MSC_FULL_VER >= 191225816 && _MSVC_LANG > 201402)
 #define FOLLY_HAVE_NOEXCEPT_FUNCTION_TYPE 1
 #endif
+
+// Define FOLLY_HAS_EXCEPTIONS
+#if __cpp_exceptions >= 199711 || FOLLY_HAS_FEATURE(cxx_exceptions)
+#define FOLLY_HAS_EXCEPTIONS 1
+#elif __GNUC__
+#if __EXCEPTIONS
+#define FOLLY_HAS_EXCEPTIONS 1
+#else // __EXCEPTIONS
+#define FOLLY_HAS_EXCEPTIONS 0
+#endif // __EXCEPTIONS
+#elif FOLLY_MICROSOFT_ABI_VER
+#if _CPPUNWIND
+#define FOLLY_HAS_EXCEPTIONS 1
+#else // _CPPUNWIND
+#define FOLLY_HAS_EXCEPTIONS 0
+#endif // _CPPUNWIND
+#else
+#define FOLLY_HAS_EXCEPTIONS 1 // default assumption for unknown platforms
+#endif
+
+// feature test __cpp_lib_string_view is defined in <string>, which is
+// too heavy to include here.  MSVC __has_include support arrived later
+// than string_view, so we need an alternate case for it.
+#ifdef __has_include
+#if __has_include(<string_view>) && __cplusplus >= 201703L
+#define FOLLY_HAS_STRING_VIEW 1
+#else
+#define FOLLY_HAS_STRING_VIEW 0
+#endif
+#else // __has_include
+#if _MSC_VER >= 1910 && (_MSVC_LANG > 201402 || __cplusplus > 201402)
+#define FOLLY_HAS_STRING_VIEW 1
+#else
+#define FOLLY_HAS_STRING_VIEW 0
+#endif
+#endif // __has_include

--- a/folly/Preprocessor.h
+++ b/folly/Preprocessor.h
@@ -31,7 +31,7 @@
  * FB_ONE_OR_NONE(hello) expands to nothing. This macro is used to
  * insert or eliminate text based on the presence of another argument.
  */
-#define FB_ONE_OR_NONE(a, ...) FB_VA_GLUE(FB_THIRD, (a, ## __VA_ARGS__, a))
+#define FB_ONE_OR_NONE(a, ...) FB_VA_GLUE(FB_THIRD, (a, ##__VA_ARGS__, a))
 #define FB_THIRD(a, b, ...) __VA_ARGS__
 
 /**

--- a/folly/Traits.h
+++ b/folly/Traits.h
@@ -26,7 +26,7 @@
 #include <folly/Portability.h>
 
 // libc++ doesn't provide this header, nor does msvc
-#ifdef FOLLY_HAVE_BITS_CXXCONFIG_H
+#if __has_include(<bits/c++config.h>)
 // This file appears in two locations: inside fbcode and in the
 // libstdc++ source code (when embedding fbstring as std::string).
 // To aid in this schizophrenic use, two macros are defined in
@@ -379,7 +379,9 @@ struct Ignore {
   template <class T>
   constexpr /* implicit */ Ignore(const T&) {}
   template <class T>
-  const Ignore& operator=(T const&) const { return *this; }
+  const Ignore& operator=(T const&) const {
+    return *this;
+  }
 };
 
 template <class...>
@@ -392,8 +394,7 @@ template <class T, class U = T>
 struct IsEqualityComparable
     : std::is_convertible<
           decltype(std::declval<T>() == std::declval<U>()),
-          bool
-      > {};
+          bool> {};
 } // namespace traits_detail_IsEqualityComparable
 
 /* using override */ using traits_detail_IsEqualityComparable::
@@ -406,8 +407,7 @@ template <class T, class U = T>
 struct IsLessThanComparable
     : std::is_convertible<
           decltype(std::declval<T>() < std::declval<U>()),
-          bool
-      > {};
+          bool> {};
 } // namespace traits_detail_IsLessThanComparable
 
 /* using override */ using traits_detail_IsLessThanComparable::
@@ -488,9 +488,8 @@ struct StrictConjunction
 
 template <class... Ts>
 struct StrictDisjunction
-  : Negation<
-      std::is_same<Bools<Ts::value...>, Bools<(Ts::value && false)...>>
-    > {};
+    : Negation<
+          std::is_same<Bools<Ts::value...>, Bools<(Ts::value && false)...>>> {};
 
 } // namespace folly
 
@@ -575,30 +574,26 @@ struct StrictDisjunction
 FOLLY_NAMESPACE_STD_BEGIN
 
 template <class T, class U>
-  struct pair;
+struct pair;
 #ifndef _GLIBCXX_USE_FB
 FOLLY_GLIBCXX_NAMESPACE_CXX11_BEGIN
 template <class T, class R, class A>
-  class basic_string;
+class basic_string;
 FOLLY_GLIBCXX_NAMESPACE_CXX11_END
 #else
 template <class T, class R, class A, class S>
-  class basic_string;
+class basic_string;
 #endif
 template <class T, class A>
-  class vector;
+class vector;
 template <class T, class A>
-  class deque;
-FOLLY_GLIBCXX_NAMESPACE_CXX11_BEGIN
-template <class T, class A>
-  class list;
-FOLLY_GLIBCXX_NAMESPACE_CXX11_END
+class deque;
 template <class T, class C, class A>
-  class set;
+class set;
 template <class K, class V, class C, class A>
-  class map;
+class map;
 template <class T>
-  class shared_ptr;
+class shared_ptr;
 
 FOLLY_NAMESPACE_STD_END
 
@@ -627,12 +622,16 @@ namespace detail {
 
 template <typename T, bool>
 struct is_negative_impl {
-  constexpr static bool check(T x) { return x < 0; }
+  constexpr static bool check(T x) {
+    return x < 0;
+  }
 };
 
 template <typename T>
 struct is_negative_impl<T, false> {
-  constexpr static bool check(T) { return false; }
+  constexpr static bool check(T) {
+    return false;
+  }
 };
 
 // folly::to integral specializations can end up generating code
@@ -649,18 +648,22 @@ FOLLY_MSVC_DISABLE_WARNING(4804) // bool-compare
 
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than_impl(LHS const lhs) {
+  // clang-format off
   return
-    rhs > std::numeric_limits<LHS>::max() ? true :
-    rhs <= std::numeric_limits<LHS>::min() ? false :
-    lhs < rhs;
+      rhs > std::numeric_limits<LHS>::max() ? true :
+      rhs <= std::numeric_limits<LHS>::min() ? false :
+      lhs < rhs;
+  // clang-format on
 }
 
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than_impl(LHS const lhs) {
+  // clang-format off
   return
-    rhs > std::numeric_limits<LHS>::max() ? false :
-    rhs < std::numeric_limits<LHS>::min() ? true :
-    lhs > rhs;
+      rhs > std::numeric_limits<LHS>::max() ? false :
+      rhs < std::numeric_limits<LHS>::min() ? true :
+      lhs > rhs;
+  // clang-format on
 }
 
 FOLLY_POP_WARNING
@@ -675,11 +678,15 @@ constexpr bool is_negative(T x) {
 
 // same as `x <= 0`
 template <typename T>
-constexpr bool is_non_positive(T x) { return !x || folly::is_negative(x); }
+constexpr bool is_non_positive(T x) {
+  return !x || folly::is_negative(x);
+}
 
 // same as `x > 0`
 template <typename T>
-constexpr bool is_positive(T x) { return !is_non_positive(x); }
+constexpr bool is_positive(T x) {
+  return !is_non_positive(x);
+}
 
 // same as `x >= 0`
 template <typename T>
@@ -689,16 +696,15 @@ constexpr bool is_non_negative(T x) {
 
 template <typename RHS, RHS rhs, typename LHS>
 bool less_than(LHS const lhs) {
-  return detail::less_than_impl<
-    RHS, rhs, typename std::remove_reference<LHS>::type
-  >(lhs);
+  return detail::
+      less_than_impl<RHS, rhs, typename std::remove_reference<LHS>::type>(lhs);
 }
 
 template <typename RHS, RHS rhs, typename LHS>
 bool greater_than(LHS const lhs) {
-  return detail::greater_than_impl<
-    RHS, rhs, typename std::remove_reference<LHS>::type
-  >(lhs);
+  return detail::
+      greater_than_impl<RHS, rhs, typename std::remove_reference<LHS>::type>(
+          lhs);
 }
 } // namespace folly
 
@@ -709,7 +715,6 @@ bool greater_than(LHS const lhs) {
 FOLLY_ASSUME_FBVECTOR_COMPATIBLE_3(std::basic_string)
 #endif
 FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::vector)
-FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::list)
 FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::deque)
 FOLLY_ASSUME_FBVECTOR_COMPATIBLE_2(std::unique_ptr)
 FOLLY_ASSUME_FBVECTOR_COMPATIBLE_1(std::shared_ptr)

--- a/folly/functional/Invoke.h
+++ b/folly/functional/Invoke.h
@@ -38,7 +38,6 @@
 namespace folly {
 
 /* using override */ using std::invoke;
-
 }
 
 #else
@@ -75,7 +74,7 @@ namespace folly {
 /* using override */ using std::is_nothrow_invocable;
 /* using override */ using std::is_nothrow_invocable_r;
 
-}
+} // namespace folly
 
 #else
 
@@ -129,10 +128,10 @@ struct is_nothrow_invocable_r : std::false_type {};
 template <typename R, typename F, typename... Args>
 struct is_nothrow_invocable_r<void_t<invoke_result_<F, Args...>>, R, F, Args...>
     : StrictConjunction<
-        std::is_convertible<invoke_result_<F, Args...>, R>,
-        invoke_nothrow_<F, Args...>> {};
+          std::is_convertible<invoke_result_<F, Args...>, R>,
+          invoke_nothrow_<F, Args...>> {};
 
-} // namespace detail
+} // namespace invoke_detail
 
 //  mimic: std::invoke_result, C++17
 template <typename F, typename... Args>

--- a/folly/portability/Config.h
+++ b/folly/portability/Config.h
@@ -24,7 +24,7 @@
 #include FOLLY_PLATFORM_CONFIG
 #endif
 
-#if FOLLY_HAVE_FEATURES_H
+#if __has_include(<features.h>)
 #include <features.h> // @manual
 #endif
 

--- a/highest_supp_cmake_cxx_standard.cmake
+++ b/highest_supp_cmake_cxx_standard.cmake
@@ -74,13 +74,7 @@ function(highest_supp_cmake_cxx_standard out_var)
 
   list(REVERSE lst_supp_cxx_stds)
   foreach(cxx_std IN LISTS lst_supp_cxx_stds)
-    try_compile(CAN_COMPILE_WITH_THIS_CXX_STANDARD ${CMAKE_CURRENT_BINARY_DIR} SOURCES ${CMAKE_CURRENT_BINARY_DIR}/try_compile.cpp
-      CXX_STANDARD ${cxx_std}
-      CXX_STANDARD_REQUIRED ON
-      CXX_EXTENSIONS OFF
-      )
-    
-    if (CAN_COMPILE_WITH_THIS_CXX_STANDARD)
+    if ("cxx_std_${cxx_std}" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
       set(${out_var} ${cxx_std} PARENT_SCOPE)
       break()
     endif()


### PR DESCRIPTION
do not fail, if a high cxx standard is not supported by the compiler

I just had the following fail: 
```bash
Target "cmTC_438fe" requires the language dialect "CXX20" , but CMake does not know the compile flags to use to enable it.
```

Now adjusted the cmake script to NOT fail, but try next lower standard (which is 17), and it worked nicely (in my setup)